### PR TITLE
Initial support for command-line completion

### DIFF
--- a/confutils.nim
+++ b/confutils.nim
@@ -515,12 +515,11 @@ proc load*(Configuration: type,
     if len(prefix) > 0:
       # Filter the options according to the input prefix
       for opt in cmd.options:
-        if longForm in filterKind:
-          if len(opt.name) > 0 and startsWithIgnoreStyle(opt.name, prefix):
+        if longForm in filterKind and len(opt.name) > 0:
+          if startsWithIgnoreStyle(opt.name, prefix):
             matchingOptions.add(opt)
-        if shortForm in filterKind:
-          if len(opt.shortform) > 0 and
-            startsWithIgnoreStyle(opt.shortform, prefix):
+        if shortForm in filterKind and len(opt.shortform) > 0:
+          if startsWithIgnoreStyle(opt.shortform, prefix):
             matchingOptions.add(opt)
     else:
       matchingOptions = cmd.options
@@ -529,9 +528,9 @@ proc load*(Configuration: type,
       # The trailing '=' means the switch accepts an argument
       let trailing = if opt.typename != "bool": "=" else: ""
 
-      if longForm in filterKind:
+      if longForm in filterKind and len(opt.name) > 0:
         stdout.writeLine("--", opt.name, trailing)
-      if shortForm in filterKind:
+      if shortForm in filterKind and len(opt.shortform) > 0:
         stdout.writeLine('-', opt.shortform, trailing)
 
   let completion = splitCompletionLine()

--- a/confutils.nim
+++ b/confutils.nim
@@ -269,17 +269,21 @@ proc completeCmdArg*(T: type[InputFile|InputDir], val: TaintedString): seq[strin
     if not show_dotfiles and path[0] == '.':
       continue
 
-    if type(T) is InputFile and kind in {pcFile, pcLinkToFile} or
-       type(T) is InputDir and kind in {pcDir, pcLinkToDir}:
-      # Note, no normalization is needed here
-      if path.startsWith(tail):
-        let match = if kind in {pcDir, pcLinkToDir}:
-          # Add a trailing slash so that completions can be chained
-          dir_path & DirSep & path & DirSep
-        else:
-          dir_path & DirSep & path
+    # Do not show files if asked for directories, on the other hand we must show
+    # directories even if a file is requested to allow the user to select a file
+    # inside those
+    if type(T) is InputDir and kind notin {pcDir, pcLinkToDir}:
+      continue
 
-        result.add(shellPathEscape(match))
+    # Note, no normalization is needed here
+    if path.startsWith(tail):
+      let match = if kind in {pcDir, pcLinkToDir}:
+        # Add a trailing slash so that completions can be chained
+        dir_path & DirSep & path & DirSep
+      else:
+        dir_path & DirSep & path
+
+      result.add(shellPathEscape(match))
 
 proc completeCmdArg*(T: type[OutFile|OutDir|OutPath], val: TaintedString): seq[string] =
   return @[]

--- a/confutils.nim
+++ b/confutils.nim
@@ -445,7 +445,7 @@ proc load*(Configuration: type,
 
     for opt in matchingOptions:
       # The trailing '=' means the switch accepts an argument
-      let trailing = if opt.typename != "bool": '=' else: ' '
+      let trailing = if opt.typename != "bool": "=" else: ""
 
       if longForm in filterKind:
         stdout.writeLine("--", opt.name, trailing)

--- a/confutils.nim
+++ b/confutils.nim
@@ -1,6 +1,6 @@
 import
   strutils, options, std_shims/macros_shim, typetraits,
-  confutils/[defs, cli_parser]
+  confutils/[defs, cli_parser, shell_completion]
 
 export
   defs
@@ -421,6 +421,92 @@ proc load*(Configuration: type,
     lastCmd.defaultSubCommand = -1
     activeCmds.add cmd
     rejectNextArgument = not cmd.hasArguments
+
+  type
+    ArgKindFilter = enum
+      longForm
+      shortForm
+
+  proc showMatchingOptions(cmd: CommandPtr, prefix: string, filterKind: set[ArgKindFilter]) =
+    var matchingOptions: seq[OptionDesc]
+
+    if len(prefix) > 0:
+      # Filter the options according to the input prefix
+      for opt in cmd.options:
+        if longForm in filterKind:
+          if len(opt.name) > 0 and normalize(opt.name).startsWith(prefix):
+            matchingOptions.add(opt)
+        if shortForm in filterKind:
+          if len(opt.shortform) > 0 and
+            normalize(opt.shortform).startsWith(prefix):
+            matchingOptions.add(opt)
+    else:
+      matchingOptions = cmd.options
+
+    for opt in matchingOptions:
+      # The trailing '=' means the switch accepts an argument
+      let trailing = if opt.typename != "bool": '=' else: ' '
+
+      if longForm in filterKind:
+        stdout.writeLine("--", opt.name, trailing)
+      if shortForm in filterKind:
+        stdout.writeLine('-', opt.shortform, trailing)
+
+  let completion = splitCompletionLine()
+  # If we're not asked to complete a command line the result is an empty list
+  if len(completion) != 0:
+    var cmdStack = @[rootCmd]
+    # Try to understand what the active chain of commands is without parsing the
+    # whole command line
+    for tok in completion[1..^1]:
+      if not tok.startsWith('-'):
+        let subCmd = findSubcommand(cmdStack[^1], tok)
+        if subCmd != nil: cmdStack.add(subCmd)
+
+    let cur_word = normalize(completion[^1])
+    let prev_word = if len(completion) > 2: normalize(completion[^2]) else: ""
+    let prev_prev_word = if len(completion) > 3: normalize(completion[^3]) else: ""
+
+    if cur_word.startsWith('-'):
+      # Show all the options matching the prefix input by the user
+      let isLong = cur_word.startsWith("--")
+      var option_word = cur_word
+      option_word.removePrefix('-')
+
+      for i in countdown(cmdStack.len - 1, 0):
+        let argFilter =
+          if isLong:
+            {longForm}
+          elif len(cur_word) > 1:
+            # If the user entered a single hypen then we show both long & short
+            # variants
+            {shortForm}
+          else:
+            {longForm, shortForm}
+
+        showMatchingOptions(cmdStack[i], option_word, argFilter)
+    elif (prev_word.startsWith('-') or
+        (prev_word == "=" and prev_prev_word.startsWith('-'))):
+      # Handle cases where we want to complete a switch choice
+      # -switch
+      # -switch=
+      var option_word = if len(prev_word) == 1: prev_prev_word else: prev_word
+      option_word.removePrefix('-')
+
+      stderr.writeLine("TODO: options for ", option_word)
+    elif len(cmdStack[^1].subCommands) != 0:
+      # Show all the available subcommands
+      for subCmd in cmdStack[^1].subCommands:
+        if startsWith(normalize(subCmd.name), cur_word):
+          stdout.writeLine(subCmd.name)
+    else:
+      # Full options listing
+      for i in countdown(cmdStack.len - 1, 0):
+        showMatchingOptions(cmdStack[i], "", {longForm, shortForm})
+
+    stdout.flushFile()
+
+    return
 
   for kind, key, val in getopt(cmdLine):
     case kind

--- a/confutils.nim
+++ b/confutils.nim
@@ -275,7 +275,11 @@ proc completeCmdArg*(T: type[InputFile|InputDir], val: TaintedString): seq[strin
        type(T) is InputDir and kind in {pcDir, pcLinkToDir}:
       # Note, no normalization is needed here
       if path.startsWith(tail):
-        result.add(dir / path)
+        if type(T) is InputDir:
+          # Add a trailing slash so that completions can be chained
+          result.add(dir / path & '/')
+        else:
+          result.add(dir / path)
 
 proc completeCmdArg*(T: type[OutFile|OutDir|OutPath], val: TaintedString): seq[string] =
   return @[]

--- a/confutils.nim
+++ b/confutils.nim
@@ -257,7 +257,7 @@ proc completeCmdArg(T: type bool, val: TaintedString): seq[string] =
 proc completeCmdArg(T: type string, val: TaintedString): seq[string] =
   return @[]
 
-proc completeCmdArg*(T: type[InputFile|InputDir], val: TaintedString): seq[string] =
+proc completeCmdArg*(T: type[InputFile|InputDir|OutFile|OutDir|OutPath], val: TaintedString): seq[string] =
   let (dir, name, ext) = splitFile(val)
   let tail = name & ext
   # Expand the directory component for the directory walker routine
@@ -272,21 +272,17 @@ proc completeCmdArg*(T: type[InputFile|InputDir], val: TaintedString): seq[strin
     # Do not show files if asked for directories, on the other hand we must show
     # directories even if a file is requested to allow the user to select a file
     # inside those
-    if type(T) is InputDir and kind notin {pcDir, pcLinkToDir}:
+    if type(T) is InputDir|OutDir and kind notin {pcDir, pcLinkToDir}:
       continue
 
     # Note, no normalization is needed here
     if path.startsWith(tail):
-      let match = if kind in {pcDir, pcLinkToDir}:
-        # Add a trailing slash so that completions can be chained
-        dir_path & DirSep & path & DirSep
-      else:
-        dir_path & DirSep & path
+      var match = dir_path / path
+      # Add a trailing slash so that completions can be chained
+      if kind in {pcDir, pcLinkToDir}:
+        match &= DirSep
 
       result.add(shellPathEscape(match))
-
-proc completeCmdArg*(T: type[OutFile|OutDir|OutPath], val: TaintedString): seq[string] =
-  return @[]
 
 proc completeCmdArg[T](_: type seq[T], val: TaintedString): seq[string] =
   return @[]

--- a/confutils.nim
+++ b/confutils.nim
@@ -138,6 +138,28 @@ proc findSubcommand(cmd: CommandPtr, name: TaintedString): CommandPtr =
 
   return nil
 
+proc startsWithIgnoreStyle(s: string, prefix: string): bool =
+  # Similar in spirit to cmpIgnoreStyle, but compare only the prefix.
+  var i = 0
+  var j = 0
+
+  while true:
+    # Skip any underscore
+    while i < s.len and s[i] == '_': inc i
+    while j < prefix.len and prefix[j] == '_': inc j
+
+    if j == prefix.len:
+      # The whole prefix matches
+      return true
+    elif i == s.len:
+      # We've reached the end of `s` without matching the prefix
+      return false
+    elif toLowerAscii(s[i]) != toLowerAscii(prefix[j]):
+      return false
+
+    inc i
+    inc j
+
 when defined(debugCmdTree):
   proc printCmdTree(cmd: CommandDesc, indent = 0) =
     let blanks = repeat(' ', indent)
@@ -221,11 +243,9 @@ proc parseCmdArgAux(T: type, s: TaintedString): T = # {.raises: [ValueError].} =
   parseCmdArg(T, s)
 
 proc completeCmdArg(T: type enum, val: TaintedString): seq[string] =
-  let norm_prefix = normalize(val)
-
   for e in low(T)..high(T):
     let as_str = $e
-    if as_str.startsWith(norm_prefix):
+    if startsWithIgnoreStyle(as_str, val):
       result.add($e)
 
 proc completeCmdArg(T: type SomeNumber, val: TaintedString): seq[string] =
@@ -489,16 +509,14 @@ proc load*(Configuration: type,
     var matchingOptions: seq[OptionDesc]
 
     if len(prefix) > 0:
-      # Ignore the case differences as the option parser would do
-      let norm_prefix = normalize(prefix)
       # Filter the options according to the input prefix
       for opt in cmd.options:
         if longForm in filterKind:
-          if len(opt.name) > 0 and normalize(opt.name).startsWith(norm_prefix):
+          if len(opt.name) > 0 and startsWithIgnoreStyle(opt.name, prefix):
             matchingOptions.add(opt)
         if shortForm in filterKind:
           if len(opt.shortform) > 0 and
-            normalize(opt.shortform).startsWith(norm_prefix):
+            startsWithIgnoreStyle(opt.shortform, prefix):
             matchingOptions.add(opt)
     else:
       matchingOptions = cmd.options
@@ -560,7 +578,7 @@ proc load*(Configuration: type,
     elif len(cmdStack[^1].subCommands) != 0:
       # Show all the available subcommands
       for subCmd in cmdStack[^1].subCommands:
-        if startsWith(normalize(subCmd.name), cur_word):
+        if startsWithIgnoreStyle(subCmd.name, cur_word):
           stdout.writeLine(subCmd.name)
     else:
       # Full options listing

--- a/confutils.nim
+++ b/confutils.nim
@@ -273,11 +273,13 @@ proc completeCmdArg*(T: type[InputFile|InputDir], val: TaintedString): seq[strin
        type(T) is InputDir and kind in {pcDir, pcLinkToDir}:
       # Note, no normalization is needed here
       if path.startsWith(tail):
-        if type(T) is InputDir:
+        let match = if kind in {pcDir, pcLinkToDir}:
           # Add a trailing slash so that completions can be chained
-          result.add(dir_path / path & '/')
+          dir_path & DirSep & path & DirSep
         else:
-          result.add(dir_path / path)
+          dir_path & DirSep & path
+
+        result.add(shellPathEscape(match))
 
 proc completeCmdArg*(T: type[OutFile|OutDir|OutPath], val: TaintedString): seq[string] =
   return @[]

--- a/confutils.nim
+++ b/confutils.nim
@@ -260,9 +260,7 @@ proc completeCmdArg(T: type string, val: TaintedString): seq[string] =
 proc completeCmdArg*(T: type[InputFile|InputDir], val: TaintedString): seq[string] =
   let (dir, name, ext) = splitFile(val)
   let tail = name & ext
-  # Expand the directory component for the directory walker routine, we still
-  # gotta use the user-supplied `dir` as a prefix in order to let the shell
-  # recognize the entry
+  # Expand the directory component for the directory walker routine
   let dir_path = if dir == "": "." else: expandTilde(dir)
   # Dotfiles are hidden unless the user entered a dot as prefix
   let show_dotfiles = len(name) > 0 and name[0] == '.'
@@ -277,9 +275,9 @@ proc completeCmdArg*(T: type[InputFile|InputDir], val: TaintedString): seq[strin
       if path.startsWith(tail):
         if type(T) is InputDir:
           # Add a trailing slash so that completions can be chained
-          result.add(dir / path & '/')
+          result.add(dir_path / path & '/')
         else:
-          result.add(dir / path)
+          result.add(dir_path / path)
 
 proc completeCmdArg*(T: type[OutFile|OutDir|OutPath], val: TaintedString): seq[string] =
   return @[]

--- a/confutils/shell_completion.nim
+++ b/confutils/shell_completion.nim
@@ -1,0 +1,227 @@
+## A simple lexer meant to tokenize an input string as a shell would do.
+import lexbase
+import options
+import streams
+import os
+import strutils
+
+type
+  ShellLexer = object of BaseLexer
+    preserveTrailingWs: bool
+    mergeWordBreaks: bool
+    wordBreakChars: string
+
+const
+  WORDBREAKS = "\"'@><=;|&(:"
+
+proc open(l: var ShellLexer, input: Stream, wordBreakChars: string = WORDBREAKS, preserveTrailingWs = true) =
+  lexbase.open(l, input)
+  l.preserveTrailingWs = preserveTrailingWs
+  l.mergeWordBreaks = false
+  l.wordBreakChars = wordBreakChars
+
+proc parseQuoted(l: var ShellLexer, pos: int, isSingle: bool, output: var string): int =
+  var pos = pos
+  while true:
+    case l.buf[pos]:
+      of '\c': pos = lexbase.handleCR(l, pos)
+      of '\L': pos = lexbase.handleLF(l, pos)
+      of lexbase.EndOfFile: break
+      of '\\':
+        # Consume the backslash and the following character
+        inc(pos)
+        if (isSingle and l.buf[pos] in {'\''}) or 
+          (not isSingle and l.buf[pos] in {'$', '`', '\\', '"'}):
+          # Escape the character
+          output.add(l.buf[pos])
+        else:
+          # Rewrite the escape sequence as-is
+          output.add('\\')
+          output.add(l.buf[pos])
+        inc(pos)
+      of '\"':
+        inc(pos)
+        if isSingle: output.add('\"')
+        else: break
+      of '\'':
+        inc(pos)
+        if isSingle: break
+        else: output.add('\'')
+      else:
+        output.add(l.buf[pos])
+        inc(pos)
+  return pos
+
+proc getTok(l: var ShellLexer): Option[string] =
+  var pos = l.bufpos
+
+  # Skip the initial whitespace
+  while true:
+    case l.buf[pos]:
+      of '\c': pos = lexbase.handleCR(l, pos)
+      of '\L': pos = lexbase.handleLF(l, pos)
+      of '#':
+        # Skip everything until EOF/EOL
+        while l.buf[pos] notin {'\c', '\L', lexbase.EndOfFile}:
+          inc(pos)
+      of lexbase.EndOfFile:
+        # If we did eat up some whitespace return an empty token, this is needed
+        # to find out if the string ends with whitespace.
+        if l.preserveTrailingWs and l.bufpos != pos:
+          l.bufpos = pos
+          return some("")
+        return none(string)
+      of ' ', '\t':
+        inc(pos)
+      else:
+        break
+
+  var tokLit = ""
+  # Parse the next token
+  while true:
+    case l.buf[pos]:
+      of '\c': pos = lexbase.handleCR(l, pos)
+      of '\L': pos = lexbase.handleLF(l, pos)
+      of '\'':
+        # Single-quoted string
+        inc(pos)
+        pos = parseQuoted(l, pos, true, tokLit)
+      of '"':
+        # Double-quoted string
+        inc(pos)
+        pos = parseQuoted(l, pos, false, tokLit)
+      of '\\':
+        # Escape sequence
+        inc(pos)
+        if l.buf[pos] != lexbase.EndOfFile:
+          tokLit.add(l.buf[pos])
+          inc(pos)
+      of '#', ' ', '\t', lexbase.EndOfFile:
+        break
+      else:
+        let ch = l.buf[pos]
+        if ch notin l.wordBreakChars:
+          tokLit.add(l.buf[pos])
+          inc(pos)
+        # Merge together runs of adjacent word-breaking characters if requested
+        elif l.mergeWordBreaks:
+          while l.buf[pos] in l.wordBreakChars:
+            tokLit.add(l.buf[pos])
+            inc(pos)
+          l.mergeWordBreaks = false
+          break
+        else:
+          l.mergeWordBreaks = true
+          break
+
+  l.bufpos = pos
+  return some(tokLit)
+
+proc splitCompletionLine*(): seq[string] =
+  let comp_line = os.getEnv("COMP_LINE")
+  var comp_point = parseInt(os.getEnv("COMP_POINT", "0"))
+
+  if comp_point == len(comp_line):
+    comp_point -= 1
+
+  if comp_point < 0 or comp_point > len(comp_line):
+    return @[]
+
+  # Take the useful part only
+  var strm = newStringStream(comp_line[0..comp_point])
+
+  # Split the resulting string
+  var l: ShellLexer
+  l.open(strm)
+  while true:
+    let token = l.getTok()
+    if token.isNone():
+      break
+    result.add(token.get())
+
+# Test data lifted from python's shlex unit-tests
+const data = """
+foo bar|foo|bar|
+ foo bar|foo|bar|
+ foo bar |foo|bar|
+foo   bar    bla     fasel|foo|bar|bla|fasel|
+x y  z              xxxx|x|y|z|xxxx|
+\x bar|x|bar|
+\ x bar| x|bar|
+\ bar| bar|
+foo \x bar|foo|x|bar|
+foo \ x bar|foo| x|bar|
+foo \ bar|foo| bar|
+foo "bar" bla|foo|bar|bla|
+"foo" "bar" "bla"|foo|bar|bla|
+"foo" bar "bla"|foo|bar|bla|
+"foo" bar bla|foo|bar|bla|
+foo 'bar' bla|foo|bar|bla|
+'foo' 'bar' 'bla'|foo|bar|bla|
+'foo' bar 'bla'|foo|bar|bla|
+'foo' bar bla|foo|bar|bla|
+blurb foo"bar"bar"fasel" baz|blurb|foobarbarfasel|baz|
+blurb foo'bar'bar'fasel' baz|blurb|foobarbarfasel|baz|
+""||
+''||
+foo "" bar|foo||bar|
+foo '' bar|foo||bar|
+foo "" "" "" bar|foo||||bar|
+foo '' '' '' bar|foo||||bar|
+\"|"|
+"\""|"|
+"foo\ bar"|foo\ bar|
+"foo\\ bar"|foo\ bar|
+"foo\\ bar\""|foo\ bar"|
+"foo\\" bar\"|foo\|bar"|
+"foo\\ bar\" dfadf"|foo\ bar" dfadf|
+"foo\\\ bar\" dfadf"|foo\\ bar" dfadf|
+"foo\\\x bar\" dfadf"|foo\\x bar" dfadf|
+"foo\x bar\" dfadf"|foo\x bar" dfadf|
+\'|'|
+'foo\ bar'|foo\ bar|
+'foo\\ bar'|foo\\ bar|
+"foo\\\x bar\" df'a\ 'df"|foo\\x bar" df'a\ 'df|
+\"foo|"foo|
+\"foo\x|"foox|
+"foo\x"|foo\x|
+"foo\ "|foo\ |
+foo\ xx|foo xx|
+foo\ x\x|foo xx|
+foo\ x\x\"|foo xx"|
+"foo\ x\x"|foo\ x\x|
+"foo\ x\x\\"|foo\ x\x\|
+"foo\ x\x\\""foobar"|foo\ x\x\foobar|
+"foo\ x\x\\"\'"foobar"|foo\ x\x\'foobar|
+"foo\ x\x\\"\'"fo'obar"|foo\ x\x\'fo'obar|
+"foo\ x\x\\"\'"fo'obar" 'don'\''t'|foo\ x\x\'fo'obar|don't|
+"foo\ x\x\\"\'"fo'obar" 'don'\''t' \\|foo\ x\x\'fo'obar|don't|\|
+'foo\ bar'|foo\ bar|
+'foo\\ bar'|foo\\ bar|
+foo\ bar|foo bar|
+:-) ;-)|:-)|;-)|
+áéíóú|áéíóú|
+"""
+
+when isMainModule:
+  var corpus = newStringStream(data)
+  var line = ""
+  while corpus.readLine(line):
+    let chunks = line.split('|')
+    let expr = chunks[0]
+    let expected = chunks[1..^2]
+
+    var l: ShellLexer
+    var strm = newStringStream(expr)
+    var got: seq[string]
+    l.open(strm, wordBreakChars="", preserveTrailingWs=false)
+    while true:
+      let x = l.getTok()
+      if x.isNone():
+        break
+      got.add(x.get())
+
+    if got != expected:
+      echo "got ", got
+      echo "expected ", expected
+      assert(false)

--- a/confutils/shell_completion.nim
+++ b/confutils/shell_completion.nim
@@ -140,7 +140,7 @@ proc splitCompletionLine*(): seq[string] =
       break
     result.add(token.get())
 
-proc quoteWord*(word: string): string =
+proc shellQuote*(word: string): string =
   if len(word) == 0:
     return "''"
 
@@ -153,6 +153,15 @@ proc quoteWord*(word: string): string =
     result.add(ch)
 
   result.add('\'')
+
+proc shellPathEscape*(path: string): string =
+  if allCharsInSet(path, SAFE_CHARS):
+    return path
+
+  for ch in path:
+    if ch notin SAFE_CHARS:
+      result.add('\\')
+    result.add(ch)
 
 # Test data lifted from python's shlex unit-tests
 const data = """


### PR DESCRIPTION
Here's a working protoype that seems to work just fine with my synthetic test case.
In order to do as much as possible using Nim (that is, without creating any intermediate shell script) the completion protocol defined by [Bash](https://www.gnu.org/software/bash/manual/html_node/Programmable-Completion.html) is employed, it doesn't allow us to do fancy completion tricks but allows us to support Bash, Zsh and possibly any other compatible shell without adding more code/complexity.

The `ShellLexer` is needed to "parse" the input string and it does pass all the test-cases (courtesy of CPython `shlex` module).

## What's missing

- [ ] Test this harness with a real-world application
- [x] Option argument completions
  - I plan on adding another `pragma` to allow the user to specify a custom set of completions
- [x] Shell-compatible quoting/escaping routines
- [x] Completions for file/directories

## How to test this

```sh
# Only needed for zsh
autoload -Uz bashcompinit && bashcompinit
complete -C <binary-path> <command-name>
```

CC @zah 