### PR TITLE
Added exporting of std/options

### DIFF
--- a/confutils.nim
+++ b/confutils.nim
@@ -4,7 +4,7 @@ import
   confutils/[defs, cli_parser, config_file]
 
 export
-  defs, config_file
+  defs, config_file, options
 
 const
   useBufferedOutput = defined(nimscript)


### PR DESCRIPTION
Recent addition of config_file to confutils now require clients importing `confutils` to load configuration files to also import `options`. Rather than adding this import everywhere, it may be better to simply export `options` from `confutils`.