### PR TITLE
add compile time check to detect duplicate abbr and duplicate name

### DIFF
--- a/confutils.nimble
+++ b/confutils.nimble
@@ -1,3 +1,4 @@
+import os
 mode = ScriptMode.Verbose
 
 packageName   = "confutils"
@@ -13,3 +14,18 @@ requires "nim >= 1.0.0",
 task test, "Run all tests":
   exec "nim c -r --threads:off -d:release tests/test_all"
   exec "nim c -r --threads:on -d:release tests/test_all"
+
+  exec "nim c --threads:off -d:release tests/test_duplicates"
+  exec "nim c --threads:on -d:release tests/test_duplicates"
+
+  #Also iterate over every test in tests/fail, and verify they fail to compile.
+  echo "\r\nTest Fail to Compile:"
+  for path in listFiles(thisDir() / "tests" / "fail"):
+    if path.split(".")[^1] != "nim":
+      continue
+
+    if gorgeEx("nim c " & path).exitCode != 0:
+      echo "  [OK] ", path.split(DirSep)[^1]
+    else:
+      echo "  [FAILED] ", path.split(DirSep)[^1]
+      exec "exit 1"

--- a/tests/fail/test_abbr_duplicate_root.nim
+++ b/tests/fail/test_abbr_duplicate_root.nim
@@ -1,0 +1,10 @@
+import 
+  ../../confutils, 
+  ../../confutils/defs
+  
+type
+  TestConf* = object
+    dataDir* {.abbr: "d" }: OutDir
+    importDir* {.abbr: "d" }: OutDir
+
+let c = TestConf.load()

--- a/tests/fail/test_abbr_duplicate_root_subcommand.nim
+++ b/tests/fail/test_abbr_duplicate_root_subcommand.nim
@@ -1,0 +1,19 @@
+import 
+  ../../confutils, 
+  ../../confutils/defs
+  
+type
+  Command = enum
+    noCommand
+    
+  TestConf* = object
+    dataDir* {.abbr: "d" }: OutDir    
+    
+    case cmd* {.
+      command
+      defaultValue: noCommand }: Command
+
+    of noCommand:
+      importDir* {.abbr: "d" }: OutDir
+
+let c = TestConf.load()

--- a/tests/fail/test_abbr_duplicate_subcommand.nim
+++ b/tests/fail/test_abbr_duplicate_subcommand.nim
@@ -1,0 +1,20 @@
+import 
+  ../../confutils, 
+  ../../confutils/defs
+  
+type
+  Command = enum
+    noCommand
+    
+  TestConf* = object
+    dataDir* {.abbr: "d" }: OutDir    
+    
+    case cmd* {.
+      command
+      defaultValue: noCommand }: Command
+
+    of noCommand:
+      importDir* {.abbr: "i" }: OutDir
+      importKey* {.abbr: "i" }: OutDir
+
+let c = TestConf.load()

--- a/tests/fail/test_name_duplicate_root.nim
+++ b/tests/fail/test_name_duplicate_root.nim
@@ -1,0 +1,10 @@
+import 
+  ../../confutils, 
+  ../../confutils/defs
+  
+type
+  TestConf* = object
+    dataDir* {.name: "data-dir" }: OutDir
+    importDir* {.name: "data-dir" }: OutDir
+
+let c = TestConf.load()

--- a/tests/fail/test_name_duplicate_root_subcommand.nim
+++ b/tests/fail/test_name_duplicate_root_subcommand.nim
@@ -1,0 +1,19 @@
+import 
+  ../../confutils, 
+  ../../confutils/defs
+  
+type
+  Command = enum
+    noCommand
+    
+  TestConf* = object
+    dataDir* {.name: "data-dir" }: OutDir    
+    
+    case cmd* {.
+      command
+      defaultValue: noCommand }: Command
+
+    of noCommand:
+      importDir* {.name: "data-dir" }: OutDir
+
+let c = TestConf.load()

--- a/tests/fail/test_name_duplicate_subcommand.nim
+++ b/tests/fail/test_name_duplicate_subcommand.nim
@@ -1,0 +1,20 @@
+import 
+  ../../confutils, 
+  ../../confutils/defs
+  
+type
+  Command = enum
+    noCommand
+    
+  TestConf* = object
+    dataDir* {.name: "data-dir" }: OutDir    
+    
+    case cmd* {.
+      command
+      defaultValue: noCommand }: Command
+
+    of noCommand:
+      importDir* {.name: "import-dir" }: OutDir
+      importKey* {.name: "import-dir" }: OutDir
+
+let c = TestConf.load()

--- a/tests/test_duplicates.nim
+++ b/tests/test_duplicates.nim
@@ -1,0 +1,60 @@
+import
+  ../confutils,
+  ../confutils/defs
+
+# duplicate name and abbr from different subcommand
+# at the same level is allowed
+
+# but hierarchical duplicate is not allowed
+
+type
+  Command = enum
+    noCommand
+    subCommand
+
+  BranchCmd = enum
+    branchA
+    branchB
+    
+  TestConf* = object
+    dataDir* {.abbr: "d" }: OutDir
+
+    case cmd* {.
+      command
+      defaultValue: noCommand }: Command
+
+    of noCommand:
+      importDir* {.
+        abbr: "i"
+        name: "import"
+      }: OutDir
+
+      outputDir* {.
+        abbr: "o"
+        name: "output"
+      }: OutDir
+
+    of subCommand:
+      importKey* {.
+        abbr: "i"
+        name: "import"
+      }: OutDir
+
+      case subcmd* {.
+        command
+        defaultValue: branchA }: BranchCmd
+
+      of branchA:
+        outputFolder* {.
+          abbr: "o"
+          name: "output"
+        }: OutDir
+
+      of branchB:
+        importFolder* {.
+          abbr: "f"
+          name: "import-folder"
+        }: OutDir
+
+let c = TestConf.load()
+discard c


### PR DESCRIPTION
How the algorithm works:
- Recursive depth first search from root to target node, where the target node is the current subcmd housing the new opt.
- What we want is find relevant path and discard other path.
- After we find the correct path from root to target subcmd. then we search for duplicate in this hierarchy of subcommand.
- If duplicate found, compilation will terminate with error message.
- Other non-relevant path might have the same abbr or name with current opt, but that is not a problem, a duplicate in other hierarchy path is allowed.
- The only place where all path must respect no duplication is the root node.

This additional feature is short and simple, but accompanied by quite a lot of tests, hence the number of files also not few.