### PR TITLE
feature: multiple lines long description

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,20 @@ template desc*(v: string) {.pragma.}
 A description of the configuration option that will appear in the produced
 help messages.
 
+```nim
+template longDesc*(v: string) {.pragma.}
+```
+
+A long description text that will appear below regular desc. You can use
+one of {'\n', '\r'} to break it into multiple lines. But you can't use
+'\p' as line break.
+
+```text
+ -x, --name   regular description [=defVal].
+              longdesc line one.
+              longdesc line two.
+              longdesc line three.
+```
 -----------------
 
 ```nim

--- a/confutils/defs.nim
+++ b/confutils/defs.nim
@@ -43,6 +43,7 @@ template `$`*(x: SomeDistinctString): string =
   string(x)
 
 template desc*(v: string) {.pragma.}
+template longDesc*(v: string) {.pragma.}
 template name*(v: string) {.pragma.}
 template abbr*(v: string) {.pragma.}
 template separator*(v: string) {.pragma.}


### PR DESCRIPTION
line break char: '\n', '\r'
example:

```text
 -x, --name   regular description [=defVal].
              longdesc line one.
              longdesc line two.
              longdesc line three.
```

why additional pragma?
- to keep the default value not too far away from the 'name'.