### PR TITLE
feature: add `ignore` property in addition to `hidden`

### DIFF
--- a/confutils.nim
+++ b/confutils.nim
@@ -782,11 +782,17 @@ proc cmdInfoFromType(T: NimNode): CmdInfo =
       let path = findPath(result, cmd)
       for n in path:
         checkDuplicate(n, opt, field.name)
-      cmd.opts.add opt
+
+      # the reason we check for `ignore` pragma here and not using `continue` statement
+      # is we do respect option hierarchy of subcommands
+      if field.readPragma("ignore") == nil:
+        cmd.opts.add opt
 
     else:
       checkDuplicate(result, opt, field.name)
-      result.opts.add opt
+
+      if field.readPragma("ignore") == nil:
+        result.opts.add opt
 
 macro configurationRtti(RecordType: type): untyped =
   let

--- a/confutils/defs.nim
+++ b/confutils/defs.nim
@@ -52,6 +52,7 @@ template required* {.pragma.}
 template command* {.pragma.}
 template argument* {.pragma.}
 template hidden* {.pragma.}
+template ignore* {.pragma.}
 template inlineConfiguration* {.pragma.}
 
 template implicitlySelectable* {.pragma.}

--- a/tests/test_all.nim
+++ b/tests/test_all.nim
@@ -8,6 +8,7 @@
 {. warning[UnusedImport]:off .}
 
 import
+  test_ignore,
   test_config_file,
   test_envvar
 

--- a/tests/test_ignore.nim
+++ b/tests/test_ignore.nim
@@ -1,0 +1,22 @@
+import
+  std/unittest,
+  ../confutils,
+  ../confutils/defs
+
+type
+  TestConf* = object
+    dataDir* {.
+      ignore
+      defaultValue: "nimbus"
+      name: "data-dir"}: string
+
+    logLevel* {.
+      defaultValue: "DEBUG"
+      desc: "Sets the log level."
+      name: "log-level" }: string
+
+suite "test ignore option":
+  test "ignored option have no default value":
+    let conf = TestConf.load()
+    doAssert(conf.logLevel == "DEBUG")
+    doAssert(conf.dataDir == "")


### PR DESCRIPTION
you can still set the value of a hidden option,
it just dont show up in the help text.

but using `ignore`, the is no chance you can set the value from cli.