### PR TITLE
fix BareExcept warning

### DIFF
--- a/confutils.nim
+++ b/confutils.nim
@@ -901,20 +901,14 @@ proc loadImpl[C, SecondarySources](
   let confAddr = addr result
 
   template applySetter(setterIdx: int, cmdLineVal: string) =
-    when (NimMajor, NimMinor) >= (1, 6):
-      {.warning[BareExcept]:off.}
-
     try:
       fieldSetters[setterIdx][1](confAddr[], some(cmdLineVal))
       inc fieldCounters[setterIdx]
-    except:
+    except CatchableError:
       fail("Error while processing the ",
            fgOption, fieldSetters[setterIdx][0],
            "=", cmdLineVal, resetStyle, " parameter: ",
            getCurrentExceptionMsg())
-
-    when (NimMajor, NimMinor) >= (1, 6):
-      {.warning[BareExcept]:on.}
 
   when hasCompletions:
     template getArgCompletions(opt: OptInfo, prefix: string): seq[string] =


### PR DESCRIPTION
https://github.com/status-im/nimbus-eth2/issues/4661

nimbus-eth2/vendor/nim-confutils/confutils.nim(885, 5) Warning: The bare except clause is deprecated; use `except CatchableError:` instead [BareExcept]

https://github.com/status-im/nim-confutils/blob/38dfeaaabdc6792d0f4d701621cbe34001978456/confutils.nim#L903-L917

If nothing else, 1.6.x don't all have `BareExcept` -- the more correct comparisons are `(NimMajor, NimMinor, NimPatch) >= (1, 6, 11)` or `>= (1, 6, 12)` (hopefully soon).