### PR TITLE
Fix alignment in help

### DIFF
--- a/tests/test_envvar.nim
+++ b/tests/test_envvar.nim
@@ -23,7 +23,7 @@ proc testUtils() =
     readWrite("some number", 123'u32)
     readWrite("some number 64", 123'u64)
     readWrite("some bytes", @[1.byte, 2.byte])
-    readWrite("some int list", @[4,5,6])
+    readWrite("some int list", @[4, 5, 6])
     readWrite("some array", [1.byte, 2.byte, 4.byte])
     readWrite("some string", "hello world")
     readWrite("some enum", Apple)
@@ -74,7 +74,7 @@ proc testEncoder() =
           fuel: Diesel
         ),
         wheel: 6,
-        door: [1,2,3,4],
+        door: [1, 2, 3, 4],
         suspension: [
           Suspension(dist: 1, length: 5),
           Suspension(dist: 2, length: 6),

--- a/tests/test_ignore.nim
+++ b/tests/test_ignore.nim
@@ -8,12 +8,12 @@ type
     dataDir* {.
       ignore
       defaultValue: "nimbus"
-      name: "data-dir"}: string
+      name: "data-dir".}: string
 
     logLevel* {.
       defaultValue: "DEBUG"
       desc: "Sets the log level."
-      name: "log-level" }: string
+      name: "log-level".}: string
 
 suite "test ignore option":
   test "ignored option have no default value":


### PR DESCRIPTION
Hi, first of all, I'd like to apologize for unnecessary formatting changes, let me know if you want me to try to avoid those to make the PR simpler.

This PR is an attempt to fix misalignments in help when there are options with and without `abbr` and various lengths of `abbr`  and when there are long names of options.

I've initially noticed it with `wakucanary` CLI tool:

```
 wakucanary [OPTIONS]...

The following options are available:

 -a, --address                 Multiaddress of the peer node to attempt to dial.
 -t, --timeout                 Timeout to consider that the connection failed [=chronos.seconds(10)].
 -p, --protocol                Protocol required to be supported: store,relay,lightpush,filter (can be used
                               multiple times).
 -l, --log-level               Sets the log level [=LogLevel.DEBUG].
 -np, --node-port               Listening port for waku node [=60000].
     --websocket-secure-key-path  Secure websocket key path:   '/path/to/key.txt' .
     --websocket-secure-cert-path  Secure websocket Certificate path:   '/path/to/cert.txt' .
```

and this is an attempt to fix it and make everything aligned (I am sure it will need iterations).

