### PR TITLE
remove support for Nim v1.2 and v1.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
             cpu: amd64
           #- os: windows
             #cpu: i386
-        branch: [version-1-2, version-1-4, version-1-6, version-2-0, devel]
+        branch: [version-1-6, version-2-0, devel]
         include:
           - target:
               os: linux

--- a/confutils.nim
+++ b/confutils.nim
@@ -1,12 +1,9 @@
 import
   os,
-  std/[options, strutils, wordwrap, strformat],
+  std/[enumutils, options, strutils, wordwrap, strformat],
   stew/shims/macros,
   serialization,
   confutils/[defs, cli_parser, config_file]
-
-when (NimMajor, NimMinor) > (1, 4):
-  import std/enumutils
 
 export
   options, serialization, defs, config_file
@@ -626,10 +623,7 @@ func parseEnumNormalized[T: enum](s: string): T =
   # Note: In Nim 1.6 `parseEnum` normalizes the string except for the first
   # character. Nim 1.2 would normalize for all characters. In config options
   # the latter behaviour is required so this custom function is needed.
-  when (NimMajor, NimMinor) > (1, 4):
-    genEnumCaseStmt(T, s, default = nil, ord(low(T)), ord(high(T)), normalize)
-  else:
-    parseEnum[T](s)
+  genEnumCaseStmt(T, s, default = nil, ord(low(T)), ord(high(T)), normalize)
 
 proc generateFieldSetters(RecordType: NimNode): NimNode =
   var recordDef = getImpl(RecordType)
@@ -663,12 +657,8 @@ proc generateFieldSetters(RecordType: NimNode): NimNode =
                              newCall(bindSym"requiresInput", fixedFieldType),
                              newCall(bindSym"acceptsMultipleValues", fixedFieldType))
 
-    when (NimMajor, NimMinor) >= (1, 6):
-      result.add quote do:
-        {.push hint[XCannotRaiseY]: off.}
-    else:
-      result.add quote do:
-        {.push hint[XDeclaredButNotUsed]: off.}
+    result.add quote do:
+      {.push hint[XCannotRaiseY]: off.}
 
     result.add quote do:
       proc `completerName`(val: string): seq[string] {.

--- a/confutils.nimble
+++ b/confutils.nimble
@@ -8,7 +8,7 @@ description   = "Simplified handling of command line options and config files"
 license       = "Apache License 2.0"
 skipDirs      = @["tests"]
 
-requires "nim >= 1.2.0",
+requires "nim >= 1.6.0",
          "stew",
          "serialization"
 
@@ -17,9 +17,8 @@ let lang = getEnv("NIMLANG", "c") # Which backend (c/cpp/js)
 let flags = getEnv("NIMFLAGS", "") # Extra flags for the compiler
 let verbose = getEnv("V", "") notin ["", "0"]
 
-let styleCheckStyle = if (NimMajor, NimMinor) < (1, 6): "hint" else: "error"
 let cfg =
-  " --styleCheck:usages --styleCheck:" & styleCheckStyle &
+  " --styleCheck:usages --styleCheck:error" &
   (if verbose: "" else: " --verbosity:0 --hints:off") &
   " --skipParentCfg --skipUserCfg --outdir:build --nimcache:build/nimcache -f"
 


### PR DESCRIPTION
https://github.com/nim-lang/Nim/pull/21611 means that `nim-confutils` has UB before Nim 1.6 regardless.