### PR TITLE
catch exceptions in `splitCompletionLine`

### DIFF
--- a/confutils/shell_completion.nim
+++ b/confutils/shell_completion.nim
@@ -133,12 +133,15 @@ proc splitCompletionLine*(): seq[string] =
 
   # Split the resulting string
   var l: ShellLexer
-  l.open(strm)
-  while true:
-    let token = l.getTok()
-    if token.isNone():
-      break
-    result.add(token.get())
+  try:
+    l.open(strm)
+    while true:
+      let token = l.getTok()
+      if token.isNone():
+        break
+      result.add(token.get())
+  except IOError, OSError:
+    return @[]
 
 proc shellQuote*(word: string): string =
   if len(word) == 0:


### PR DESCRIPTION
We currently return `@[]` in `splitCompletionLine` when there is unexpected or unsupported input via environment variables, but let exceptions during parsing propagate to the caller. Catching those exceptions allows the caller to use same behaviour regardless of the nature of unexpected input (either through env, or parsing). Currently, callers don't seem to be aware of the exceptions, so going with the behaviour used for environment errors of returning `@[]`.