### PR TITLE
catch exceptions in `appInvocation`

### DIFF
--- a/confutils.nim
+++ b/confutils.nim
@@ -99,7 +99,10 @@ when defined(nimscript):
 
 else:
   template appInvocation: string =
-    getAppFilename().splitFile.name
+    try:
+      getAppFilename().splitFile.name
+    except OSError:
+      ""
 
 when noColors:
   const


### PR DESCRIPTION
The `appInvocation` template in `confutils` is used while showing help, e.g., before quitting. To ensure that `quit` actually happens, it can't raise exceptions. Fix that by falling back to `""` on `OSError`.