### PR TITLE
handle `terminalWidth` exception

### DIFF
--- a/confutils.nim
+++ b/confutils.nim
@@ -373,7 +373,11 @@ proc showHelp(help: var string,
 
   appInfo.maxNameLen = cmd.maxNameLen
   appInfo.hasAbbrs = cmd.hasAbbrs
-  appInfo.terminalWidth = terminalWidth()
+  appInfo.terminalWidth =
+    try:
+      terminalWidth()
+    except ValueError:
+      int.high  # https://github.com/nim-lang/Nim/pull/21968
   appInfo.namesWidth = min(minNameWidth, appInfo.maxNameLen) + descPadding
 
   var cmdInvocation = appInfo.appInvocation


### PR DESCRIPTION
`terminalWidth()` may fail with a `ValueError` on out of range widths from environment variables. Provide a suitable fallback.