### PR TITLE
suppress unreachable string format errors

### DIFF
--- a/confutils.nim
+++ b/confutils.nim
@@ -393,7 +393,7 @@ func getNextArgIdx(cmd: CmdInfo, consumedArgIdx: int): int =
 
   -1
 
-proc noMoreArgsError(cmd: CmdInfo): string =
+proc noMoreArgsError(cmd: CmdInfo): string {.raises: [].} =
   result =
     if cmd.isSubCommand:
       try:
@@ -859,7 +859,7 @@ proc addConfigFileContent*(secondarySources: auto,
   except IOError:
     raiseAssert "This should not be possible"
 
-func constructEnvKey*(prefix: string, key: string): string =
+func constructEnvKey*(prefix: string, key: string): string {.raises: [].} =
   ## Generates env. variable names from keys and prefix following the
   ## IEEE Open Group env. variable spec: https://pubs.opengroup.org/onlinepubs/000095399/basedefs/xbd_chap08.html
   try:

--- a/confutils.nim
+++ b/confutils.nim
@@ -397,8 +397,14 @@ func getNextArgIdx(cmd: CmdInfo, consumedArgIdx: int): int =
   -1
 
 proc noMoreArgsError(cmd: CmdInfo): string =
-  result = if cmd.isSubCommand: "The command '$1'" % [cmd.name]
-           else: appInvocation()
+  result =
+    if cmd.isSubCommand:
+      try:
+        "The command '$1'" % [cmd.name]
+      except ValueError as err:
+        raiseAssert "strutils.`%` failed: " & err.msg
+    else:
+      appInvocation()
   result.add " does not accept"
   if cmd.hasArgs: result.add " additional"
   result.add " arguments"
@@ -866,8 +872,10 @@ proc addConfigFileContent*(secondarySources: auto,
 func constructEnvKey*(prefix: string, key: string): string =
   ## Generates env. variable names from keys and prefix following the
   ## IEEE Open Group env. variable spec: https://pubs.opengroup.org/onlinepubs/000095399/basedefs/xbd_chap08.html
-
-  return (&"{prefix}_{key}").toUpperAscii.multiReplace(("-", "_"), (" ", "_"))
+  try:
+    (&"{prefix}_{key}").toUpperAscii.multiReplace(("-", "_"), (" ", "_"))
+  except ValueError as err:
+    raiseAssert "strformat.`&` failed: " & err.msg
 
 proc loadImpl[C, SecondarySources](
     Configuration: typedesc[C],


### PR DESCRIPTION
We use `%` and `&` to format some strings, which may raise `ValueError` if the format string is weird. As we are using them in ways that should always succeed, catch those `ValueError` and convert to asserts.