### PR TITLE
fail on error while processing `secondarySources`

### DIFF
--- a/confutils.nim
+++ b/confutils.nim
@@ -842,7 +842,7 @@ macro configurationRtti(RecordType: type): untyped =
 
 proc addConfigFile*(secondarySources: auto,
                     Format: type,
-                    path: InputFile) =
+                    path: InputFile) {.raises: [ConfigurationError].} =
   try:
     secondarySources.data.add loadFile(Format, string path,
                                        type(secondarySources.data[0]))
@@ -877,9 +877,11 @@ proc loadImpl[C, SecondarySources](
     printUsage = true,
     quitOnFailure = true,
     secondarySourcesRef: ref SecondarySources,
-    secondarySources: proc (config: Configuration,
-                            sources: ref SecondarySources) = nil,
-    envVarsPrefix = getAppFilename()): Configuration =
+    secondarySources: proc (
+        config: Configuration, sources: ref SecondarySources
+    ) {.raises: [ConfigurationError].} = nil,
+    envVarsPrefix = getAppFilename()
+): Configuration {.raises: [ConfigurationError].} =
   ## Loads a program configuration by parsing command-line arguments
   ## and a standard set of config files that can specify:
   ##
@@ -1108,7 +1110,10 @@ proc loadImpl[C, SecondarySources](
     activateCmd(subCmdDiscriminator, defaultCmd)
 
   if secondarySources != nil:
-    secondarySources(result, secondarySourcesRef)
+    try:
+      secondarySources(result, secondarySourcesRef)
+    except ConfigurationError as err:
+      fail "Failed to load secondary sources: '$1'" % [err.msg]
 
   proc processMissingOpts(conf: var Configuration, cmd: CmdInfo) =
     for opt in cmd.opts:

--- a/tests/test_config_file.nim
+++ b/tests/test_config_file.nim
@@ -182,7 +182,9 @@ proc testConfigFile() =
     putEnv("PREFIX_DATA_DIR", "ENV VAR DATADIR")
 
     test "basic config file":
-      let conf = TestConf.load(envVarsPrefix="prefix", secondarySources = proc (config: TestConf, sources: auto) =
+      let conf = TestConf.load(envVarsPrefix="prefix", secondarySources = proc (
+            config: TestConf, sources: auto
+      ) {.raises: [ConfigurationError].} =
         if config.configFile.isSome:
           sources.addConfigFile(Toml, config.configFile.get)
         else:


### PR DESCRIPTION
The way how `secondarySources` are used in `status-im/nimbus-eth2`, they call `addConfigFile` again which may raise `ConfigurationError`. When that happened, loading the primary config file didn't result in `fail`, which differs in error handling from errors within itself as opposed to within `secondarySources`. To keep callers concise, apply same error handling behaviour regardless of whether the error occurred during primary or secondary sources processing.