### PR TITLE
add `{.raises.}` annotation to `writeValue`

### DIFF
--- a/confutils/winreg/writer.nim
+++ b/confutils/winreg/writer.nim
@@ -14,7 +14,7 @@ proc init*(T: type WinregWriter,
   result.hKey = hKey
   result.path = path
 
-proc writeValue*(w: var WinregWriter, value: auto) =
+proc writeValue*(w: var WinregWriter, value: auto) {.raises: [IOError].} =
   mixin enumInstanceSerializedFields, writeValue, writeFieldIMPL
   # TODO: reduce allocation
 

--- a/tests/test_winreg.nim
+++ b/tests/test_winreg.nim
@@ -47,7 +47,8 @@ type
 proc readValue(r: var WinregReader, value: var ValidIpAddress) =
   r.readValue(value.value)
 
-proc writeValue(w: var WinregWriter, value: ValidIpAddress) =
+proc writeValue(
+    w: var WinregWriter, value: ValidIpAddress) {.raises: [IOError].} =
   w.writeValue(value.value)
 
 suite "optional fields test suite":


### PR DESCRIPTION
Tag `writeValue` override with `{.raises: [IOError].}`.