### PR TITLE
add missing `{.raises.}` to `addConfigFileContent`

### DIFF
--- a/confutils.nim
+++ b/confutils.nim
@@ -881,7 +881,7 @@ proc addConfigFile*(secondarySources: auto,
 
 proc addConfigFileContent*(secondarySources: auto,
                            Format: type,
-                           content: string) =
+                           content: string) {.raises: [ConfigurationError].} =
   try:
     secondarySources.data.add decode(Format, content,
                                      type(secondarySources.data[0]))


### PR DESCRIPTION
`addConfigFileContent` can raise `ConfigurationError`. Declare so.