### PR TITLE
Fix `cli` invocation from nimscript

### DIFF
--- a/confutils.nim
+++ b/confutils.nim
@@ -1158,6 +1158,7 @@ proc loadImpl[C, SecondarySources](
     let defaultCmd = subCmdDiscriminator.subCmds[subCmdDiscriminator.defaultSubCmd]
     result.activateCmd(subCmdDiscriminator, defaultCmd)
 
+  # https://github.com/status-im/nim-confutils/pull/109#discussion_r1820076739
   if not isNil(secondarySources):  # Nim v2.0.10: `!= nil` broken in nimscript
     try:
       secondarySources(result, secondarySourcesRef)

--- a/confutils.nimble
+++ b/confutils.nimble
@@ -66,7 +66,7 @@ task test, "Run all tests":
       baz = true
       arg ./tests/cli_example.nim
       arg 42"""
-  if expectedOutput == actualOutput:
+  if actualOutput.strip() == expectedOutput:
     echo "  [OK] tests/cli_example.nim"
   else:
     echo "  [FAILED] tests/cli_example.nim"

--- a/confutils.nimble
+++ b/confutils.nimble
@@ -54,3 +54,20 @@ task test, "Run all tests":
     else:
       echo "  [FAILED] ", path.split(DirSep)[^1]
       quit(QuitFailure)
+
+  echo "\r\nNimscript test:"
+  let
+    actualOutput = gorgeEx(
+      nimc & " --verbosity:0 e " & flags & " " & "./tests/cli_example.nim " &
+      "--foo=1 --bar=2 --withBaz 42").output
+    expectedOutput = unindent"""
+      foo = 1
+      bar = 2
+      baz = true
+      arg ./tests/cli_example.nim
+      arg 42"""
+  if expectedOutput == actualOutput:
+    echo "  [OK] tests/cli_example.nim"
+  else:
+    echo "  [FAILED] tests/cli_example.nim"
+    quit(QuitFailure)

--- a/confutils.nimble
+++ b/confutils.nimble
@@ -70,4 +70,5 @@ task test, "Run all tests":
     echo "  [OK] tests/cli_example.nim"
   else:
     echo "  [FAILED] tests/cli_example.nim"
+    echo actualOutput
     quit(QuitFailure)


### PR DESCRIPTION
When calling `cli` macro from nimscript, there are compilation issues:

- `nim-faststreams` is not available, therefore, `nim-serialization` does not work, due to `equalMem` being gated behind `notJSnotNims`. Dropping support for config files in nimscript contexts fixes that.

- `std/strformat` raises `ValueError` for invalid format strings, but does so at runtime rather than checking types at compiletime. As it is only used for simple string concatenation in error cases, changing to simple concatenation avoids verbose error handling.

- `getAppFilename()` is unavailable in `nimscript`. This was already fixed by replacing it with `appInvocation()` but two instances of direct `getAppFilename()` calls remained in default arguments. This is fixed by changing those default arguments as well.

- The `!= nil` check on the `proc` in `loadImpl` does not work when called from nimscript. This is fixed by changing to `isNil`.

- Passing `addr result` around to internal templates correctly creates the config, but the object ultimately being returned is not the same. Passing `var result` directly through the templates ensures that the correct `result` gets modified and is clearer than implicit capture.

Applying these fixes fixes running `.nims` files with `cli` macro.