### PR TITLE
Fix #112; add results.Opt support

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ template required* {.pragma.}
 ```
 
 By default, all options without default values are considered required.
-An exception to this rule are all `seq[T]` or `Option[T]` options for
+An exception to this rule are all `seq[T]` or `Opt[T]` or `Option[T]` options for
 which the "empty" value can be considered a reasonable default. You can
 also extend this behavior to other user-defined types by providing the
 following overloads:

--- a/confutils.nimble
+++ b/confutils.nimble
@@ -19,7 +19,8 @@ skipDirs      = @["tests"]
 
 requires "nim >= 1.6.0",
          "stew",
-         "serialization"
+         "serialization",
+         "results"
 
 let nimc = getEnv("NIMC", "nim") # Which nim compiler to use
 let lang = getEnv("NIMLANG", "c") # Which backend (c/cpp/js)
@@ -44,6 +45,7 @@ task test, "Run all tests":
   for threads in ["--threads:off", "--threads:on"]:
     run threads, "tests/test_all"
     build threads, "tests/test_duplicates"
+    run threads, "confutils/shell_completion"
 
   #Also iterate over every test in tests/fail, and verify they fail to compile.
   echo "\r\nTest Fail to Compile:"

--- a/confutils/shell_completion.nim
+++ b/confutils/shell_completion.nim
@@ -8,11 +8,9 @@
 # those terms.
 
 ## A simple lexer meant to tokenize an input string as a shell would do.
-import lexbase
-import options
-import streams
-import os
-import strutils
+import
+  std/[lexbase, streams, os, strutils],
+  results
 
 type
   ShellLexer = object of BaseLexer
@@ -70,7 +68,7 @@ proc parseQuoted(l: var ShellLexer,
         inc(pos)
   return pos
 
-proc getTok(l: var ShellLexer): Option[string] {.gcsafe, raises: [IOError, OSError].} =
+proc getTok(l: var ShellLexer): Opt[string] {.gcsafe, raises: [IOError, OSError].} =
   var pos = l.bufpos
 
   # Skip the initial whitespace
@@ -87,8 +85,8 @@ proc getTok(l: var ShellLexer): Option[string] {.gcsafe, raises: [IOError, OSErr
         # to find out if the string ends with whitespace.
         if l.preserveTrailingWs and l.bufpos != pos:
           l.bufpos = pos
-          return some("")
-        return none(string)
+          return Opt.some("")
+        return Opt.none(string)
       of ' ', '\t':
         inc(pos)
       else:
@@ -133,7 +131,7 @@ proc getTok(l: var ShellLexer): Option[string] {.gcsafe, raises: [IOError, OSErr
           break
 
   l.bufpos = pos
-  return some(tokLit)
+  return Opt.some(tokLit)
 
 proc splitCompletionLine*(): seq[string] =
   let comp_line = os.getEnv("COMP_LINE")

--- a/tests/test_all.nim
+++ b/tests/test_all.nim
@@ -18,6 +18,7 @@ import
   test_parsecmdarg,
   test_pragma,
   test_qualified_ident,
+  test_results_opt,
   test_help
 
 when defined(windows):

--- a/tests/test_results_opt.nim
+++ b/tests/test_results_opt.nim
@@ -1,0 +1,79 @@
+# confutils
+# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+import unittest2, ../confutils
+
+type CustomString = distinct string
+
+proc `==`(a, b: CustomString): bool =
+  a.string == b.string
+
+proc parseCmdArg(T: type CustomString, s: string): T {.raises: [ValueError].} =
+  T(s & "_cs_overridden")
+
+func completeCmdArg(T: type CustomString, val: string): seq[string] =
+  @[]
+
+type
+  Lvl1Cmd = enum
+    lvl1Cmd1
+
+  Lvl2Cmd = enum
+    lvl2Cmd1
+
+  TestConf = object
+    opt1 {.
+      desc: "opt1 desc"
+      name: "opt1" }: Opt[string]
+    opt2 {.
+      desc: "opt2 desc"
+      name: "opt2" }: Opt[CustomString]
+
+    case cmd {.command.}: Lvl1Cmd
+    of Lvl1Cmd.lvl1Cmd1:
+      lvl1Opt1 {.
+        desc: "lvl1Opt1 desc"
+        name: "lvl1-opt1" }: Opt[int]
+
+      case cmd2 {.command.}: Lvl2Cmd
+      of Lvl2Cmd.lvl2Cmd1:
+        lvl2Opt1 {.
+          desc: "lvl2Opt1 desc"
+          name: "lvl2-opt1" }: Opt[int]
+
+suite "test results Opt":
+  test "defaults":
+    let conf = TestConf.load(cmdLine = @[
+      "lvl1Cmd1",
+      "lvl2Cmd1"
+    ])
+    check:
+      conf.cmd == Lvl1Cmd.lvl1Cmd1
+      conf.cmd2 == Lvl2Cmd.lvl2Cmd1
+      not conf.opt1.isOk
+      not conf.opt2.isOk
+      not conf.lvl1Opt1.isOk
+      not conf.lvl2Opt1.isOk
+
+  test "all opts":
+    let conf = TestConf.load(cmdLine = @[
+      "--opt1=foo",
+      "--opt2=bar",
+      "lvl1Cmd1",
+      "--lvl1-opt1=123",
+      "lvl2Cmd1",
+      "--lvl2-opt1=456"
+    ])
+    check:
+      conf.cmd == Lvl1Cmd.lvl1Cmd1
+      conf.cmd2 == Lvl2Cmd.lvl2Cmd1
+      conf.opt1.get == "foo"
+      conf.opt2.get == "bar_cs_overridden".CustomString
+      conf.lvl1Opt1.get == 123
+      conf.lvl2Opt1.get == 456


### PR DESCRIPTION
Fix #112

- Use results throughout; except for config_files internals which require toml support, pending https://github.com/status-im/nim-toml-serialization/pull/100
- Add Opt[T] support for option types.

Alternatively it could be moved to a `confutils/pkg/results`, but since it's used internally and would need to be exported anyway, I think there is no point in that.

Note I tried changing Optional to results.Opt in nimbus-eth2, but to do so it requires switching throughout (otherwise is a PITA). That means adding Opt support to nim-presto and nim-toml-ser, maybe other libs too (nim-eth db but I don't think so).