### PR TITLE
Fix #87; Support env var value list

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,17 @@ it must be prefixed with `$` (i.e: converted to string).
 -----------------
 
 ```nim
+template envVarValueSep*(v: string = "") {.pragma.}
+```
+
+Apply to a field to get its environment variable value split by
+the set delimiter. Use it with collection types such as `seq[T]`
+and `distinct seq[T]`. The following leading and trailing
+characters are stripped from each individual item: `{'\t', ' '}`.
+
+-----------------
+
+```nim
 template required* {.pragma.}
 ```
 

--- a/confutils.nim
+++ b/confutils.nim
@@ -69,6 +69,7 @@ type
     name, abbr, desc, typename: string
     separator: string
     longDesc: string
+    envVarValueSep: string
     idx: int
     flags: set[OptFlag]
     hasDefault: bool
@@ -896,6 +897,7 @@ proc cmdInfoFromType(T: NimNode): CmdInfo =
       defaultInHelpText = toText(defaultInHelp)
       separator = field.readPragma"separator"
       longDesc = field.readPragma"longDesc"
+      envVarValueSep = field.readPragma"envVarValueSep"
       abbr = field.readPragma"abbr"
       name = field.readPragma"name"
       desc = field.readPragma"desc"
@@ -917,6 +919,7 @@ proc cmdInfoFromType(T: NimNode): CmdInfo =
     if abbr != nil: opt.abbr = abbr.strVal
     if separator != nil: opt.separator = separator.strVal
     if longDesc != nil: opt.longDesc = longDesc.strVal
+    if envVarValueSep != nil: opt.envVarValueSep = envVarValueSep.strVal
 
     inc fieldIdx
 
@@ -1332,7 +1335,11 @@ proc loadImpl[C, SecondarySources](
         try:
           if existsEnv(envKey):
             let envContent = getEnv(envKey)
-            conf.applySetter(opt.idx, envContent)
+            if opt.envVarValueSep.len == 0:
+              conf.applySetter(opt.idx, envContent)
+            else:
+              for v in envContent.split(opt.envVarValueSep):
+                conf.applySetter(opt.idx, v.strip(chars = {'\t', ' '}))
           elif secondarySourcesRef.setters[opt.idx](conf, secondarySourcesRef):
             # all work is done in the config file setter,
             # there is nothing left to do here.

--- a/confutils/defs.nim
+++ b/confutils/defs.nim
@@ -60,6 +60,7 @@ template abbr*(v: string) {.pragma.}
 template separator*(v: string) {.pragma.}
 template defaultValue*(v: untyped) {.pragma.}
 template defaultValueDesc*(v: string) {.pragma.}
+template envVarValueSep*(v = "") {.pragma.}
 template required* {.pragma.}
 template command* {.pragma.}
 template argument* {.pragma.}

--- a/tests/test_envvar.nim
+++ b/tests/test_envvar.nim
@@ -34,6 +34,16 @@ type
       abbr: "d"
       name: "data-dir" }: OutDir
 
+    urlList* {.
+      envVarValueSep: ","
+      desc: "List of urls"
+      name: "url-list" }: seq[string]
+
+    numList* {.
+      envVarValueSep: ";"
+      desc: "List of numbers"
+      name: "num-list" }: seq[int]
+
 func completeCmdArg(T: type SomeObject, val: string): seq[string] =
   @[]
 
@@ -63,5 +73,25 @@ proc testEnvvar() =
       let conf = TestConf.load(envVarsPrefix=EnvVarPrefix)
       check conf.somObject.name.string == "helloObject"
       check conf.somObject.isNice.bool == true
+
+    test "list separator with single string item":
+      putEnv("NIMBUS_URL_LIST", "abc")
+      let conf = TestConf.load(envVarsPrefix=EnvVarPrefix)
+      check conf.urlList == @["abc"]
+
+    test "list separator with many string items":
+      putEnv("NIMBUS_URL_LIST", "abc, def,ghi")
+      let conf = TestConf.load(envVarsPrefix=EnvVarPrefix)
+      check conf.urlList == @["abc", "def", "ghi"]
+
+    test "list separator with single number item":
+      putEnv("NIMBUS_NUM_LIST", "123")
+      let conf = TestConf.load(envVarsPrefix=EnvVarPrefix)
+      check conf.numList == @[123]
+
+    test "list separator with many number items":
+      putEnv("NIMBUS_NUM_LIST", "123; 456; 789")
+      let conf = TestConf.load(envVarsPrefix=EnvVarPrefix)
+      check conf.numList == @[123, 456, 789]
 
 testEnvvar()


### PR DESCRIPTION
Fix #87

Changes:

- Add `envVarValueSep` pragma to split env var values by a given separator

This way the user can set what separator they want for a given type. It works for seq and distinct types, or any other type.