### PR TITLE
Fix #74; envVarsPrefix app file name when not set

### DIFF
--- a/confutils.nim
+++ b/confutils.nim
@@ -109,12 +109,15 @@ when defined(nimscript):
   func scriptNameParamIdx: int =
     for i in 1 ..< paramCount():
       var param = paramStr(i)
-      if param.len > 0 and param[0] != '-':
+      if param.len > 0 and param[0] != '-' and param != "e":
         return i
 
   proc appInvocation: string =
     let scriptNameIdx = scriptNameParamIdx()
-    "nim " & (if paramCount() > scriptNameIdx: paramStr(scriptNameIdx) else: "<nims-script>")
+    if paramCount() > scriptNameIdx:
+      paramStr(scriptNameIdx).splitFile.name
+    else:
+      ""
 
   type stderr = object
 

--- a/confutils.nimble
+++ b/confutils.nimble
@@ -67,7 +67,6 @@ task test, "Run all tests":
       foo = 1
       bar = 2
       baz = true
-      arg ./tests/cli_example.nim
       arg 42"""
   if actualOutput.strip() == expectedOutput:
     echo "  [OK] tests/cli_example.nim"

--- a/tests/help/.gitignore
+++ b/tests/help/.gitignore
@@ -1,5 +1,6 @@
 /*
 !*/
 !/*.nim
+!/*.nims
 !.gitignore
 !README.md

--- a/tests/help/snapshots/test_cli_example.txt
+++ b/tests/help/snapshots/test_cli_example.txt
@@ -1,0 +1,10 @@
+Usage: 
+
+test_cli_example [OPTIONS]... <args>
+
+The following options are available:
+
+ --help         Show this help message and exit.
+ --foo        
+ --bar        
+ --withBaz

--- a/tests/help/snapshots/test_cli_example_nims.txt
+++ b/tests/help/snapshots/test_cli_example_nims.txt
@@ -1,0 +1,10 @@
+Usage: 
+
+test_cli_example [OPTIONS]... <args>
+
+The following options are available:
+
+ --help         Show this help message and exit.
+ --foo        
+ --bar        
+ --withBaz

--- a/tests/help/test_cli_example.nim
+++ b/tests/help/test_cli_example.nim
@@ -1,0 +1,7 @@
+import ../../confutils
+
+cli do (foo: int, bar: string, withBaz: bool, args {.argument.}: seq[string]):
+  echo "foo = ", foo
+  echo "bar = ", bar
+  echo "baz = ", withBaz
+  for arg in args: echo "arg ", arg

--- a/tests/help/test_cli_example.nims
+++ b/tests/help/test_cli_example.nims
@@ -1,0 +1,1 @@
+import ./test_cli_example

--- a/tests/test_envvar.nim
+++ b/tests/test_envvar.nim
@@ -94,4 +94,14 @@ proc testEnvvar() =
       let conf = TestConf.load(envVarsPrefix=EnvVarPrefix)
       check conf.numList == @[123, 456, 789]
 
+    test "default envVarsPrefix is app file name":
+      const prefix =
+        when isMainModule:
+          "TEST_ENVVAR"
+        else:
+          "TEST_ALL"
+      putEnv(prefix & "_DATA_DIR", "ENV VAR DATADIR")
+      let conf = TestConf.load()
+      check conf.dataDir.string == "ENV VAR DATADIR"
+
 testEnvvar()


### PR DESCRIPTION
Fix #74 

This got fixed for binaries [here](https://github.com/status-im/nim-confutils/pull/109/files#diff-f9f65e02f59d7af0a3a221a3896a3a80f81b09a16640a9ac36b3a1b9bfa1ad3eL1197).

This PR fixes it for nimscript. Changes:

- Set `envVarsPrefix` to the file name in nimscript
- Skip `e` for `nim e script.nim` so it works the same as running `nim script.nims`
- Add regression tests