### PR TITLE
Fix #59; Allow `&` in command desc

### DIFF
--- a/tests/help/snapshots/test_default_cmd_desc_lines.txt
+++ b/tests/help/snapshots/test_default_cmd_desc_lines.txt
@@ -1,0 +1,15 @@
+Usage: 
+
+test_default_cmd_desc_lines [OPTIONS]... command
+
+This multi line work.
+
+The following options are available:
+
+ --help  Show this help message and exit.
+
+Available sub-commands:
+
+test_default_cmd_desc_lines printCommand
+
+Multi lines with these triple quoted strings work.

--- a/tests/help/test_default_cmd_desc_lines.nim
+++ b/tests/help/test_default_cmd_desc_lines.nim
@@ -1,0 +1,35 @@
+# confutils
+# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+import ../../confutils
+
+type
+  ExporterCmd* = enum
+    exportCommand =
+      "This multi " &
+      "line " &
+      "work"
+    printCommand =
+      "Multi lines with these " &
+      "triple quoted strings work"
+
+# TODO: 
+#    printCommand = """Multi lines with these
+#  triple quoted strings work"""
+
+  ExporterConf* = object
+    case cmd* {.
+      command
+      defaultValue: exportCommand .}: ExporterCmd
+    of exportCommand:
+      discard
+    of printCommand:
+      discard
+
+let c = ExporterConf.load(termWidth = int.high)

--- a/tests/help/test_default_cmd_desc_lines.nim
+++ b/tests/help/test_default_cmd_desc_lines.nim
@@ -19,7 +19,7 @@ type
       "Multi lines with these " &
       "triple quoted strings work"
 
-# TODO: 
+# TODO: https://github.com/nim-lang/Nim/pull/25401
 #    printCommand = """Multi lines with these
 #  triple quoted strings work"""
 

--- a/tests/test_help.nim
+++ b/tests/test_help.nim
@@ -117,5 +117,6 @@ suite "test --help":
   test "test test_default_cmd_desc printCommand":
     cmdTest("test_default_cmd_desc", "printCommand")
 
-  test "test test_default_cmd_desc_lines":
-    cmdTest("test_default_cmd_desc_lines", "")
+  when NimMajor >= 2:
+    test "test test_default_cmd_desc_lines":
+      cmdTest("test_default_cmd_desc_lines", "")

--- a/tests/test_help.nim
+++ b/tests/test_help.nim
@@ -116,3 +116,6 @@ suite "test --help":
 
   test "test test_default_cmd_desc printCommand":
     cmdTest("test_default_cmd_desc", "printCommand")
+
+  test "test test_default_cmd_desc_lines":
+    cmdTest("test_default_cmd_desc_lines", "")


### PR DESCRIPTION
Fix #59

This fix is pretty limited though. A better fix would evaluate the values. For this 1. need to stop using desc to look up the sub-command, 2. don't store the desc for sub-commands, 3. get the desc at runtime (similar to applySetter; but get instead of set). Alternatively, maybe just populate desc field at runtime.

In Nim 1.6 genEnumCaseStmt errors out. It could be fixed by generating an enum case of elements instead of values; it currently sets the enum [by value](https://github.com/status-im/nim-confutils/blob/ee06c587562ed6a175cb32565b5ebc1b6371c4a5/confutils.nim#L1152) desc if present (which is a bit iffy).

Edit: see if it's just step 3, like done in #145. I forgot the details of this issue.