### PR TITLE
Fix #19 #52; Evaluate `defaultValueDesc` and `defaultValue` in help message

### DIFF
--- a/confutils.nim
+++ b/confutils.nim
@@ -895,15 +895,17 @@ proc generateFieldSetters(RecordType: NimNode): NimNode =
           setField(`configField`, val, `defaultValue`)
 
       proc `defaultValueHelpName`(): string {.compileTime.} =
-        # defaultValue can be `config.otherField` which won't compile
-        # `$` may not be defined for this type
-        when compiles($`defaultValueHelp`):
-          when typeof($`defaultValueHelp`) is string:
-            $`defaultValueHelp`
+        # this runs at comptime so gcsafe cast is ok
+        {.cast(gcsafe).}
+          # defaultValue can be `config.otherField` which won't compile
+          # `$` may not be defined for this type
+          when compiles($`defaultValueHelp`):
+            when typeof($`defaultValueHelp`) is string:
+              $`defaultValueHelp`
+            else:
+              `defaultValueHelpRepr`
           else:
             `defaultValueHelpRepr`
-        else:
-          `defaultValueHelpRepr`
 
     result.add quote do:
       {.pop.}

--- a/confutils.nim
+++ b/confutils.nim
@@ -896,7 +896,7 @@ proc generateFieldSetters(RecordType: NimNode): NimNode =
 
       proc `defaultValueHelpName`(): string {.compileTime.} =
         # this runs at comptime so gcsafe cast is ok
-        {.cast(gcsafe).}
+        {.cast(gcsafe).}:
           # defaultValue can be `config.otherField` which won't compile
           # `$` may not be defined for this type
           when compiles($`defaultValueHelp`):

--- a/confutils.nim
+++ b/confutils.nim
@@ -865,7 +865,7 @@ proc generateFieldSetters(RecordType: NimNode): NimNode =
                              completerName,
                              newCall(bindSym"requiresInput", fixedFieldType),
                              newCall(bindSym"acceptsMultipleValues", fixedFieldType),
-                             defaultValueHelpName)
+                             newCall(defaultValueHelpName))
 
     result.add quote do:
       {.push hint[XCannotRaiseY]: off.}
@@ -895,22 +895,21 @@ proc generateFieldSetters(RecordType: NimNode): NimNode =
         else:
           setField(`configField`, val, `defaultValue`)
 
-      proc `defaultValueHelpName`(`configVar`: `RecordType`): string {.
-        nimcall
-        gcsafe
-        sideEffect
-        raises: []
-      .} =
-        when `defaultValueHelp` is string:
-          `defaultValueHelp`
-        else:
-          when compiles($`defaultValueHelp`):
-            when typeof($`defaultValueHelp`) is string:
-              $`defaultValueHelp`
+      proc `defaultValueHelpName`(): string {.compileTime.} =
+        # defaultValue can be `config.otherField` which won't compile
+        when compiles(`defaultValueHelp` is string):
+          when `defaultValueHelp` is string:
+            `defaultValueHelp`
+          else:
+            when compiles($`defaultValueHelp`):
+              when typeof($`defaultValueHelp`) is string:
+                $`defaultValueHelp`
+              else:
+                `defaultValueHelpRepr`
             else:
               `defaultValueHelpRepr`
-          else:
-            `defaultValueHelpRepr`
+        else:
+          `defaultValueHelpRepr`
 
     result.add quote do:
       {.pop.}
@@ -1345,7 +1344,7 @@ proc loadImpl[C, SecondarySources](
   template getDefaultValueDescs(): seq[string] =
     var defaultValueDescs = newSeq[string](fieldSetters.len)
     for i in 0 ..< fieldSetters.len:
-      defaultValueDescs[i] = fieldSetters[i][5](result)
+      defaultValueDescs[i] = fieldSetters[i][5]
     defaultValueDescs
 
   template processHelpAndVersionOptions(optKey, optVal: string) =

--- a/confutils.nim
+++ b/confutils.nim
@@ -837,11 +837,17 @@ proc generateFieldSetters(RecordType: NimNode): NimNode =
       defaultValue = field.readPragma"defaultValue"
       completerName = ident($field.name & "Complete")
       isFieldDiscriminator = newLit field.isDiscriminator
+      defaultValueDesc = field.readPragma"defaultValueDesc"
       defaultValueHelp =
-        if field.readPragma"defaultValueDesc" != nil:
-          field.readPragma"defaultValueDesc"
+        if defaultValueDesc != nil:
+          defaultValueDesc
         elif defaultValue != nil:
           defaultValue
+        else:
+          newLit("")
+      defaultValueHelpRepr =
+        if defaultValueDesc == nil and defaultValue != nil:
+          newLit(repr defaultValue)
         else:
           newLit("")
       defaultValueHelpName = ident($field.name & "DefaultValueHelp")
@@ -893,24 +899,18 @@ proc generateFieldSetters(RecordType: NimNode): NimNode =
         nimcall
         gcsafe
         sideEffect
-        raises: [ConfigurationError]
+        raises: []
       .} =
-        try:
-          when `defaultValueHelp` is string:
-            `defaultValueHelp`
-          else:
-            when compiles($`defaultValueHelp`):
-              when typeof($`defaultValueHelp`) is string:
-                $`defaultValueHelp`
-              else:
-                repr(`defaultValueHelp`)
+        when `defaultValueHelp` is string:
+          `defaultValueHelp`
+        else:
+          when compiles($`defaultValueHelp`):
+            when typeof($`defaultValueHelp`) is string:
+              $`defaultValueHelp`
             else:
-              repr(`defaultValueHelp`)
-        except CatchableError as err:
-          raise (ref ConfigurationError)(
-            msg: "Failed to evaluate defaultValue help text; error: " & err.msg,
-            parent: err
-          )
+              `defaultValueHelpRepr`
+          else:
+            `defaultValueHelpRepr`
 
     result.add quote do:
       {.pop.}

--- a/confutils.nim
+++ b/confutils.nim
@@ -75,7 +75,6 @@ type
     idx: int
     flags: set[OptFlag]
     hasDefault: bool
-    defaultInHelpText: string
     obsoleteMsg: string
     case kind: OptKind
     of Discriminator:
@@ -942,11 +941,6 @@ func findPath(parent, node: CmdInfo): seq[CmdInfo] =
   doAssert validPath(result, parent, node)
   result.add parent
 
-func toText(n: NimNode): string =
-  if n == nil: ""
-  elif n.kind in {nnkStrLit..nnkTripleStrLit}: n.strVal
-  else: repr(n)
-
 func readPragmaFlags(field: FieldDescription): set[OptFlag] =
   result = {}
   if field.readPragma("hidden") != nil:
@@ -968,10 +962,6 @@ proc cmdInfoFromType(T: NimNode): CmdInfo =
     let
       isImplicitlySelectable = field.readPragma"implicitlySelectable" != nil
       defaultValue = field.readPragma"defaultValue"
-      defaultValueDesc = field.readPragma"defaultValueDesc"
-      defaultInHelp = if defaultValueDesc != nil: defaultValueDesc
-                      else: defaultValue
-      defaultInHelpText = toText(defaultInHelp)
       obsoleteMsg = field.readPragma"obsolete"
       separator = field.readPragma"separator"
       longDesc = field.readPragma"longDesc"
@@ -989,7 +979,6 @@ proc cmdInfoFromType(T: NimNode): CmdInfo =
                       name: $field.name,
                       flags: optFlags,
                       hasDefault: defaultValue != nil,
-                      defaultInHelpText: defaultInHelpText,
                       typename: field.typ.repr)
 
     if desc != nil: opt.desc = desc.strVal

--- a/confutils.nim
+++ b/confutils.nim
@@ -896,17 +896,12 @@ proc generateFieldSetters(RecordType: NimNode): NimNode =
 
       proc `defaultValueHelpName`(): string {.compileTime.} =
         # defaultValue can be `config.otherField` which won't compile
-        when compiles(`defaultValueHelp` is string):
-          when `defaultValueHelp` is string:
-            `defaultValueHelp`
+        # `$` may not be defined for this type
+        when compiles($`defaultValueHelp`):
+          when typeof($`defaultValueHelp`) is string:
+            $`defaultValueHelp`
           else:
-            when compiles($`defaultValueHelp`):
-              when typeof($`defaultValueHelp`) is string:
-                $`defaultValueHelp`
-              else:
-                `defaultValueHelpRepr`
-            else:
-              `defaultValueHelpRepr`
+            `defaultValueHelpRepr`
         else:
           `defaultValueHelpRepr`
 

--- a/confutils.nim
+++ b/confutils.nim
@@ -50,6 +50,7 @@ type
     terminalWidth: int
     namesWidth: int
     flags: set[HelpFlag]
+    defaultValueDescs: seq[string]
 
   CmdInfo = ref object
     name: string
@@ -193,6 +194,12 @@ const
 template flushOutputAndQuit(exitCode: int) =
   flushOutput
   quit exitCode
+
+func defaultValueDesc(appInfo: HelpAppInfo, optIdx: int): string =
+  if optIdx == -1:
+    ""
+  else:
+    appInfo.defaultValueDescs[optIdx]
 
 func helpOptDesc(appInfo: HelpAppInfo): string =
   result = "Show this help message and exit"
@@ -367,7 +374,7 @@ proc describeInvocation(
       let cliArg = "<" & arg.name & ">"
       helpOutput fgArg, styleBright, cliArg
       helpOutput padding(cliArg, appInfo.namesWidth)
-      help.writeDesc appInfo, arg.desc, arg.defaultInHelpText
+      help.writeDesc appInfo, arg.desc, appInfo.defaultValueDesc(arg.idx)
       help.writeLongDesc appInfo, arg.longDesc
       helpOutput "\p"
 
@@ -410,7 +417,7 @@ proc describeOptionsList(
     if opt.desc.len > 0:
       help.writeDesc appInfo,
                       opt.desc.replace("%t", opt.typename),
-                      opt.defaultInHelpText
+                      appInfo.defaultValueDesc(opt.idx)
       help.writeLongDesc appInfo, opt.longDesc
 
     helpOutput "\p"
@@ -445,14 +452,16 @@ proc describeOptions(
       let helpOpt = OptInfo(
         kind: CliSwitch,
         name: "help",
-        desc: helpOptDesc(appInfo)
+        desc: helpOptDesc(appInfo),
+        idx: -1
       )
       describeOptionsList(help, [helpOpt], appInfo, excl)
       if appInfo.hasVersion:
         let versionOpt = OptInfo(
           kind: CliSwitch,
           name: "version",
-          desc: "Show program's version and exit"
+          desc: "Show program's version and exit",
+          idx: -1
         )
         describeOptionsList(help, [versionOpt], appInfo, excl)
 
@@ -828,6 +837,14 @@ proc generateFieldSetters(RecordType: NimNode): NimNode =
       defaultValue = field.readPragma"defaultValue"
       completerName = ident($field.name & "Complete")
       isFieldDiscriminator = newLit field.isDiscriminator
+      defaultValueHelp =
+        if field.readPragma"defaultValueDesc" != nil:
+          field.readPragma"defaultValueDesc"
+        elif defaultValue != nil:
+          defaultValue
+        else:
+          newLit("")
+      defaultValueHelpName = ident($field.name & "DefaultValueHelp")
 
     if defaultValue == nil:
       defaultValue = newCall(makeDefaultValue, newTree(nnkTypeOfExpr, configField))
@@ -838,9 +855,11 @@ proc generateFieldSetters(RecordType: NimNode): NimNode =
 
     settersArray.add newTree(nnkTupleConstr,
                              newLit($paramName),
-                             setterName, completerName,
+                             setterName,
+                             completerName,
                              newCall(bindSym"requiresInput", fixedFieldType),
-                             newCall(bindSym"acceptsMultipleValues", fixedFieldType))
+                             newCall(bindSym"acceptsMultipleValues", fixedFieldType),
+                             defaultValueHelpName)
 
     result.add quote do:
       {.push hint[XCannotRaiseY]: off.}
@@ -869,6 +888,23 @@ proc generateFieldSetters(RecordType: NimNode): NimNode =
             setField(`configField`, val, `defaultValue`)
         else:
           setField(`configField`, val, `defaultValue`)
+
+      proc `defaultValueHelpName`(`configVar`: `RecordType`): string {.
+        nimcall
+        gcsafe
+        sideEffect
+        raises: []
+      .} =
+        when `defaultValueHelp` is string:
+          `defaultValueHelp`
+        else:
+          when compiles($`defaultValueHelp`):
+            when typeof($`defaultValueHelp`) is string:
+              $`defaultValueHelp`
+            else:
+              repr(`defaultValueHelp`)
+          else:
+            repr(`defaultValueHelp`)
 
     result.add quote do:
       {.pop.}
@@ -1290,19 +1326,27 @@ proc loadImpl[C, SecondarySources](
 
       return
 
-  proc lazyHelpAppInfo(flags: set[HelpFlag]): HelpAppInfo =
+  proc lazyHelpAppInfo(flags: set[HelpFlag], defaultValueDescs: seq[string]): HelpAppInfo =
     HelpAppInfo(
       copyrightBanner: copyrightBanner,
       appInvocation: appInvocation(),
       terminalWidth: termWidth,
       hasVersion: version.len > 0,
-      flags: flags
+      flags: flags,
+      defaultValueDescs: defaultValueDescs
     )
+
+  template getDefaultValueDescs(): seq[string] =
+    var defaultValueDescs = newSeq[string](fieldSetters.len)
+    for i in 0 ..< fieldSetters.len:
+      defaultValueDescs[i] = fieldSetters[i][5](result)
+    defaultValueDescs
 
   template processHelpAndVersionOptions(optKey, optVal: string) =
     let key = optKey
     if cmpIgnoreStyle(key, "help") == 0:
-      help.showHelp(lazyHelpAppInfo(optVal.toHelpFlags), activeCmds)
+      let defaultValueDescs = getDefaultValueDescs()
+      help.showHelp(lazyHelpAppInfo(optVal.toHelpFlags, defaultValueDescs), activeCmds)
     elif version.len > 0 and cmpIgnoreStyle(key, "version") == 0:
       help.helpOutput version, "\p"
       flushOutputAndQuit QuitSuccess

--- a/confutils.nim
+++ b/confutils.nim
@@ -893,18 +893,24 @@ proc generateFieldSetters(RecordType: NimNode): NimNode =
         nimcall
         gcsafe
         sideEffect
-        raises: []
+        raises: [ConfigurationError]
       .} =
-        when `defaultValueHelp` is string:
-          `defaultValueHelp`
-        else:
-          when compiles($`defaultValueHelp`):
-            when typeof($`defaultValueHelp`) is string:
-              $`defaultValueHelp`
+        try:
+          when `defaultValueHelp` is string:
+            `defaultValueHelp`
+          else:
+            when compiles($`defaultValueHelp`):
+              when typeof($`defaultValueHelp`) is string:
+                $`defaultValueHelp`
+              else:
+                repr(`defaultValueHelp`)
             else:
               repr(`defaultValueHelp`)
-          else:
-            repr(`defaultValueHelp`)
+        except CatchableError as err:
+          raise (ref ConfigurationError)(
+            msg: "Failed to evaluate defaultValue help text; error: " & err.msg,
+            parent: err
+          )
 
     result.add quote do:
       {.pop.}

--- a/confutils.nim
+++ b/confutils.nim
@@ -864,7 +864,7 @@ proc generateFieldSetters(RecordType: NimNode): NimNode =
                              completerName,
                              newCall(bindSym"requiresInput", fixedFieldType),
                              newCall(bindSym"acceptsMultipleValues", fixedFieldType),
-                             newCall(defaultValueHelpName))
+                             defaultValueHelpName)
 
     result.add quote do:
       {.push hint[XCannotRaiseY]: off.}
@@ -894,18 +894,21 @@ proc generateFieldSetters(RecordType: NimNode): NimNode =
         else:
           setField(`configField`, val, `defaultValue`)
 
-      proc `defaultValueHelpName`(): string {.compileTime.} =
-        # this runs at comptime so gcsafe cast is ok
-        {.cast(gcsafe).}:
-          # defaultValue can be `config.otherField` which won't compile
-          # `$` may not be defined for this type
-          when compiles($`defaultValueHelp`):
-            when typeof($`defaultValueHelp`) is string:
-              $`defaultValueHelp`
-            else:
-              `defaultValueHelpRepr`
+      proc `defaultValueHelpName`(): string {.
+        nimcall
+        gcsafe
+        sideEffect
+        raises: []
+      .} =
+        # defaultValue can be `config.otherField` which won't compile
+        # `$` may not be defined for this type
+        when compiles($`defaultValueHelp`):
+          when typeof($`defaultValueHelp`) is string:
+            $`defaultValueHelp`
           else:
             `defaultValueHelpRepr`
+        else:
+          `defaultValueHelpRepr`
 
     result.add quote do:
       {.pop.}
@@ -1330,7 +1333,7 @@ proc loadImpl[C, SecondarySources](
   template getDefaultValueDescs(): seq[string] =
     var defaultValueDescs = newSeq[string](fieldSetters.len)
     for i in 0 ..< fieldSetters.len:
-      defaultValueDescs[i] = fieldSetters[i][5]
+      defaultValueDescs[i] = fieldSetters[i][5]()
     defaultValueDescs
 
   template processHelpAndVersionOptions(optKey, optVal: string) =

--- a/tests/help/snapshots/test_default_value_desc.txt
+++ b/tests/help/snapshots/test_default_value_desc.txt
@@ -7,3 +7,4 @@ The following options are available:
  --help      Show this help message and exit.
  --opt1      tcp port [=9000].
  --opt2      tcp port 2 [=9000].
+ --opt3      distinct string [=foobar].

--- a/tests/help/snapshots/test_default_value_desc.txt
+++ b/tests/help/snapshots/test_default_value_desc.txt
@@ -6,3 +6,4 @@ The following options are available:
 
  --help      Show this help message and exit.
  --opt1      tcp port [=9000].
+ --opt2      tcp port 2 [=9000].

--- a/tests/help/snapshots/test_default_value_desc.txt
+++ b/tests/help/snapshots/test_default_value_desc.txt
@@ -4,11 +4,17 @@ test_default_value_desc [OPTIONS]...
 
 The following options are available:
 
- --help      Show this help message and exit.
- --opt1      tcp port [=9000].
- --opt2      tcp port 2 [=9000].
- --opt3      tcp port 3 [=overridden].
- --opt4      tcp port 4 [=overridden].
- --opt5      distinct string [=foobar].
- --opt6      no dollar func defined [=NoDollar("default")].
- --opt7      no dollar func defined [=overridden].
+ --help       Show this help message and exit.
+ --opt1       tcp port [=9000].
+ --opt2       tcp port 2 [=9000].
+ --opt3       const default value desc [=ok].
+ --opt4       literal default value desc [=ok].
+ --opt5       distinct string [=ok].
+ --opt6       no dollar func defined [=NoDollar("default")].
+ --opt7       no dollar func defined with default desc [=ok].
+ --opt8       runtime value [=ok].
+ --opt9       runtime value [=ok].
+ --opt10      runtime value [=ok concat].
+ --opt11      default value can raise but default desc won't [=ok].
+ --opt12      default is config.opt11 [=config.opt11].
+ --opt13      default is config.opt11 with default desc [=ok].

--- a/tests/help/snapshots/test_default_value_desc.txt
+++ b/tests/help/snapshots/test_default_value_desc.txt
@@ -18,3 +18,4 @@ The following options are available:
  --opt11      default value can raise but default desc won't [=ok].
  --opt12      default is config.opt11 [=config.opt11].
  --opt13      default is config.opt11 with default desc [=ok].
+ --opt14      default enum is TestEnum.OK [=OK].

--- a/tests/help/snapshots/test_default_value_desc.txt
+++ b/tests/help/snapshots/test_default_value_desc.txt
@@ -7,4 +7,6 @@ The following options are available:
  --help      Show this help message and exit.
  --opt1      tcp port [=9000].
  --opt2      tcp port 2 [=9000].
- --opt3      distinct string [=foobar].
+ --opt3      tcp port 3 [=overridden].
+ --opt4      tcp port 4 [=overridden].
+ --opt5      distinct string [=foobar].

--- a/tests/help/snapshots/test_default_value_desc.txt
+++ b/tests/help/snapshots/test_default_value_desc.txt
@@ -10,3 +10,5 @@ The following options are available:
  --opt3      tcp port 3 [=overridden].
  --opt4      tcp port 4 [=overridden].
  --opt5      distinct string [=foobar].
+ --opt6      no dollar func defined [=NoDollar("default")].
+ --opt7      no dollar func defined [=overridden].

--- a/tests/help/test_default_value_desc.nim
+++ b/tests/help/test_default_value_desc.nim
@@ -10,6 +10,7 @@
 import ../../confutils
 
 const defaultEth2TcpPort = 9000
+const defaultDescOverride = "overridden"
 
 type DisString = distinct string
 
@@ -38,8 +39,20 @@ type
       name: "opt2" }: int
 
     opt3 {.
+      defaultValue: defaultEth2TcpPort
+      defaultValueDesc: defaultDescOverride
+      desc: "tcp port 3"
+      name: "opt3" }: int
+
+    opt4 {.
+      defaultValue: defaultEth2TcpPort
+      defaultValueDesc: "overridden"
+      desc: "tcp port 4"
+      name: "opt4" }: int
+
+    opt5 {.
       defaultValue: DisString("this should not show in the help message")
       desc: "distinct string"
-      name: "opt3" }: DisString
+      name: "opt5" }: DisString
 
 let c = TestConf.load(termWidth = int.high)

--- a/tests/help/test_default_value_desc.nim
+++ b/tests/help/test_default_value_desc.nim
@@ -7,17 +7,18 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
+import os
 import ../../confutils
 
 const defaultEth2TcpPort = 9000
-const defaultDescOverride = "overridden"
+const defaultDescOverride = "ok"
 
 type DisString = distinct string
 type NoDollar = distinct string
 
 proc `$`(s: DisString): string =
   # this should show in the help message
-  "foobar"
+  "ok"
 
 proc completeCmdArg(T: type DisString, val: string): seq[string] =
   completeCmdArg(string, val)
@@ -31,6 +32,18 @@ proc completeCmdArg(T: type NoDollar, val: string): seq[string] =
 proc parseCmdArg(T: type NoDollar, s: string): T =
   parseCmdArg(string, s).NoDollar
 
+proc runtimeVal(): string =
+  # do something that's not available at comptime
+  {.cast(raises: []).}:
+    discard getCurrentProcessId()
+  "ok"
+
+proc canRaise(): string {.raises: [ValueError].} =
+  # do something that's not available at comptime
+  if false:
+    raise (ref ValueError)(msg: "never raised")
+  "bad"
+
 type
   TestConf = object
     opt1 {.
@@ -41,24 +54,23 @@ type
 
     opt2 {.
       defaultValue: defaultEth2TcpPort
-      #defaultValueDesc: $defaultEth2TcpPort
       desc: "tcp port 2"
       name: "opt2" }: int
 
     opt3 {.
-      defaultValue: defaultEth2TcpPort
+      defaultValue: "bad"
       defaultValueDesc: defaultDescOverride
-      desc: "tcp port 3"
-      name: "opt3" }: int
+      desc: "const default value desc"
+      name: "opt3" }: string
 
     opt4 {.
-      defaultValue: defaultEth2TcpPort
-      defaultValueDesc: "overridden"
-      desc: "tcp port 4"
-      name: "opt4" }: int
+      defaultValue: "bad"
+      defaultValueDesc: "ok"
+      desc: "literal default value desc"
+      name: "opt4" }: string
 
     opt5 {.
-      defaultValue: DisString("this should not show in the help message")
+      defaultValue: DisString("bad")
       desc: "distinct string"
       name: "opt5" }: DisString
 
@@ -68,9 +80,43 @@ type
       name: "opt6" }: NoDollar
 
     opt7 {.
-      defaultValue: NoDollar("default")
-      defaultValueDesc: "overridden"
-      desc: "no dollar func defined"
+      defaultValue: NoDollar("bad")
+      defaultValueDesc: "ok"
+      desc: "no dollar func defined with default desc"
       name: "opt7" }: NoDollar
+
+    opt8 {.
+      defaultValue: runtimeVal()
+      desc: "runtime value"
+      name: "opt8" }: string
+
+    opt9 {.
+      defaultValue: "bad"
+      defaultValueDesc: runtimeVal()
+      desc: "runtime value"
+      name: "opt9" }: string
+
+    opt10 {.
+      defaultValue: "bad"
+      defaultValueDesc: runtimeVal() & " concat"
+      desc: "runtime value"
+      name: "opt10" }: string
+
+    opt11 {.
+      defaultValue: canRaise()
+      defaultValueDesc: "ok"
+      desc: "default value can raise but default desc won't"
+      name: "opt11" }: string
+
+    opt12 {.
+      defaultValue: config.opt11
+      desc: "default is config.opt11"
+      name: "opt12" }: string
+
+    opt13 {.
+      defaultValue: config.opt11
+      defaultValueDesc: "ok"
+      desc: "default is config.opt11 with default desc"
+      name: "opt13" }: string
 
 let c = TestConf.load(termWidth = int.high)

--- a/tests/help/test_default_value_desc.nim
+++ b/tests/help/test_default_value_desc.nim
@@ -13,6 +13,10 @@ import ../../confutils
 const defaultEth2TcpPort = 9000
 const defaultDescOverride = "ok"
 
+type TestEnum {.pure.} = enum
+  BAD
+  OK
+
 type DisString = distinct string
 type NoDollar = distinct string
 
@@ -118,5 +122,10 @@ type
       defaultValueDesc: "ok"
       desc: "default is config.opt11 with default desc"
       name: "opt13" }: string
+
+    opt14 {.
+      defaultValue: TestEnum.OK
+      desc: "default enum is TestEnum.OK"
+      name: "opt14" }: TestEnum
 
 let c = TestConf.load(termWidth = int.high)

--- a/tests/help/test_default_value_desc.nim
+++ b/tests/help/test_default_value_desc.nim
@@ -13,6 +13,7 @@ const defaultEth2TcpPort = 9000
 const defaultDescOverride = "overridden"
 
 type DisString = distinct string
+type NoDollar = distinct string
 
 proc `$`(s: DisString): string =
   # this should show in the help message
@@ -23,6 +24,12 @@ proc completeCmdArg(T: type DisString, val: string): seq[string] =
 
 proc parseCmdArg(T: type DisString, s: string): T =
   parseCmdArg(string, s).DisString
+
+proc completeCmdArg(T: type NoDollar, val: string): seq[string] =
+  completeCmdArg(string, val)
+
+proc parseCmdArg(T: type NoDollar, s: string): T =
+  parseCmdArg(string, s).NoDollar
 
 type
   TestConf = object
@@ -54,5 +61,16 @@ type
       defaultValue: DisString("this should not show in the help message")
       desc: "distinct string"
       name: "opt5" }: DisString
+
+    opt6 {.
+      defaultValue: NoDollar("default")
+      desc: "no dollar func defined"
+      name: "opt6" }: NoDollar
+
+    opt7 {.
+      defaultValue: NoDollar("default")
+      defaultValueDesc: "overridden"
+      desc: "no dollar func defined"
+      name: "opt7" }: NoDollar
 
 let c = TestConf.load(termWidth = int.high)

--- a/tests/help/test_default_value_desc.nim
+++ b/tests/help/test_default_value_desc.nim
@@ -11,6 +11,18 @@ import ../../confutils
 
 const defaultEth2TcpPort = 9000
 
+type DisString = distinct string
+
+proc `$`(s: DisString): string =
+  # this should show in the help message
+  "foobar"
+
+proc completeCmdArg(T: type DisString, val: string): seq[string] =
+  completeCmdArg(string, val)
+
+proc parseCmdArg(T: type DisString, s: string): T =
+  parseCmdArg(string, s).DisString
+
 type
   TestConf = object
     opt1 {.
@@ -24,5 +36,10 @@ type
       #defaultValueDesc: $defaultEth2TcpPort
       desc: "tcp port 2"
       name: "opt2" }: int
+
+    opt3 {.
+      defaultValue: DisString("this should not show in the help message")
+      desc: "distinct string"
+      name: "opt3" }: DisString
 
 let c = TestConf.load(termWidth = int.high)

--- a/tests/help/test_default_value_desc.nim
+++ b/tests/help/test_default_value_desc.nim
@@ -19,4 +19,10 @@ type
       desc: "tcp port"
       name: "opt1" }: int
 
+    opt2 {.
+      defaultValue: defaultEth2TcpPort
+      #defaultValueDesc: $defaultEth2TcpPort
+      desc: "tcp port 2"
+      name: "opt2" }: int
+
 let c = TestConf.load(termWidth = int.high)


### PR DESCRIPTION
Fixes #19
Fixes #52

Changes:

- This generates a new function that evaluates `defaultValueDesc` (preferred) and `defaultValue` (fallback) conversion to string. It's only called when `--help` is set.

I tried making this `{.compileTime.}` but some default values cannot be evaluated [for example this](https://github.com/status-im/nimbus-eth1/blob/a851ca9ddc8d102db5c39181a49f2205f92fc9af/execution_chain/conf.nim#L56) fails.